### PR TITLE
Remove pytest-runner

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,6 @@ Click==7.0
 pytest==6.2.1
 pytest-asyncio==0.14.0
 pytest-env==0.6.2
-pytest-runner==5.2
 pytest-mock==3.4.0
 pytest-cov==2.10.1
 bleak==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ requirements = [
     'bleak>=0.10.0',
 ]
 
-setup_requirements = ['pytest-runner', ]
-
 test_requirements = ['pytest>=3', ]
 
 setup(
@@ -46,7 +44,6 @@ setup(
     keywords='pyzerproc',
     name='pyzerproc',
     packages=find_packages(include=['pyzerproc', 'pyzerproc.*']),
-    setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/emlove/pyzerproc',


### PR DESCRIPTION
`pytest-runner` is not used but it picked-up during the build process for distribution packages and make those packages depend on `pytest-runner`.