### PR TITLE
Use built-in AsyncMock on Python 3.8+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements_dev.txt
+        if [[ "${{ matrix.python-version}}" == "3.6" ]] || [[ "${{ matrix.python-version }}" == "3.7" ]] ; then pip install asynctest==0.13.0 ; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 pip==19.2.3
 wheel==0.33.6
 flake8==3.7.8
-tox==3.14.0
+tox==3.15.0
 coverage==5.3
 coveralls==2.2.0
 twine==1.14.0
@@ -12,4 +12,3 @@ pytest-env==0.6.2
 pytest-mock==3.4.0
 pytest-cov==2.10.1
 bleak==0.10.0
-asynctest==0.13.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,23 @@
 import pytest
-import asynctest
+import sys
 
 import bleak
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest import patch, MagicMock
+else:
+    from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture
 def client_class():
-    with asynctest.patch('bleak.BleakClient', autospec=True) as client_class:
+    with patch('bleak.BleakClient', autospec=True) as client_class:
         yield client_class
 
 
 @pytest.fixture
 def client(client_class):
-    client = asynctest.MagicMock(spec=bleak.BleakClient)
+    client = MagicMock(spec=bleak.BleakClient)
     client_class.return_value = client
 
     connected = False
@@ -38,5 +43,5 @@ def client(client_class):
 
 @pytest.fixture
 def scanner():
-    with asynctest.patch('bleak.BleakScanner', autospec=True) as scanner:
+    with patch('bleak.BleakScanner', autospec=True) as scanner:
         yield scanner

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import asyncio
-import asynctest
 import pytest
 
 import bleak
 
 from pyzerproc import Light, LightState, ZerprocException
+from .conftest import MagicMock
 
 
 @pytest.mark.asyncio
@@ -84,7 +84,7 @@ async def test_turn_on(client):
     client.write_gatt_char.assert_called_with(
         '0000ffe9-0000-1000-8000-00805f9b34fb', b'\xCC\x23\x33')
 
-    light._write = asynctest.MagicMock()
+    light._write = MagicMock()
     light._write.side_effect = asyncio.TimeoutError("Mock timeout")
 
     with pytest.raises(ZerprocException):
@@ -102,7 +102,7 @@ async def test_turn_off(client):
     client.write_gatt_char.assert_called_with(
         '0000ffe9-0000-1000-8000-00805f9b34fb', b'\xCC\x24\x33')
 
-    light._write = asynctest.MagicMock()
+    light._write = MagicMock()
     light._write.side_effect = asyncio.TimeoutError("Mock timeout")
 
     with pytest.raises(ZerprocException):
@@ -139,7 +139,7 @@ async def test_set_color(client):
     with pytest.raises(ValueError):
         await light.set_color(999, 999, 999)
 
-    light._write = asynctest.MagicMock()
+    light._write = MagicMock()
     light._write.side_effect = asyncio.TimeoutError("Mock timeout")
 
     with pytest.raises(ZerprocException):
@@ -198,7 +198,7 @@ async def test_get_state(client):
 
     # Test response timeout
     client.write_gatt_char.side_effect = None
-    light._notification_queue = asynctest.MagicMock()
+    light._notification_queue = MagicMock()
 
     async def get_queue(*args, **kwargs):
         """Simulate a queue timeout"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,6 @@
 [tox]
 envlist = py36, py37, py38, flake8
 
-[travis]
-python =
-    3.8: py38
-    3.7: py37
-    3.6: py36
-
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
@@ -21,3 +15,8 @@ commands =
 [testenv:flake8]
 basepython = python
 commands = flake8 pyzerproc tests
+
+[testenv:{py36,py37}]
+deps =
+    -r{toxinidir}/requirements_dev.txt
+    asynctest==0.13.0


### PR DESCRIPTION
## Description
This PR switches the tests to use Python's built-in async mock on Python 3.8+. For older Python versions, we'll continue pulling in the asyncmock dependency.

Fixes https://github.com/emlove/pyzerproc/issues/3